### PR TITLE
add description about servicecomb.provider.rest.scanRestController

### DIFF
--- a/java-chassis-reference/en_US/build-provider/springmvc.md
+++ b/java-chassis-reference/en_US/build-provider/springmvc.md
@@ -5,7 +5,7 @@ ServiceComb supports Spring MVC annotations to define your REST services. The [s
 
 ## Development Example
 
-### Define the service interface （optional）
+### Step1 Define the service interface （optional）
 
 Writing a interface for the REST service make it easy to call the service in client in RPC style.
 
@@ -16,7 +16,9 @@ public interface Hello {
 }
 ```
 
-* **Step 2** Implement the services. Spring MVC is used to describe the development of service code. The implementation of the Hello service is as follow:
+### Step2 Implement the services
+
+The annotations of Spring MVC are used to describe the development of service code. The implementation of the Hello service is as follow:
 
  ```java
 @RestSchema(schemaId = "springmvcHello")
@@ -36,7 +38,7 @@ public class SpringmvcHelloImpl implements Hello {
 }
 ```
 
-### add a component scan （optional）
+### Step3 add a component scan （optional）
 
 create `resources/META-INF/spring` folder and add `springmvcprovider.bean.xml`, add component-scan to specify the bean package. This step is optional. The package where main class located is automatically added.
 
@@ -53,9 +55,9 @@ create `resources/META-INF/spring` folder and add `springmvcprovider.bean.xml`, 
 </beans>
 ```
 
-### Wrtie a main class
+### Step4 Wrtie a main class
 
-This code using log4j as the logger framework. Users can change it to any other favorite logger framework. 
+This code using log4j as the logger framework. Users can change it to any other favorite logger framework.
 
 ```java
 public class SpringmvcProviderMain {
@@ -71,7 +73,7 @@ public class SpringmvcProviderMain {
 
 ### Description
 
-SpringBoot supports to map a bean parameter to HTTP queries. 
+SpringBoot supports to map a bean parameter to HTTP queries.
 ```java
 @RequestMapping("/hello")
 public class HelloService {
@@ -84,11 +86,11 @@ public class HelloService {
 ```
 
 ServiceComb supports this usage too, but has following constraints.
-1. Must not add any mapping annotations, such as @QueryParam
+1. Must not add any mapping annotations, such as `@QueryParam`
 2. Only map to query parameters, headers and forms not supported.
 3. Variables name in POJO definition must be the same as query keys.
 4. Only primitive and String types supported in POJO, add `@JsonIgnore` to other types to ignore it.
-5. In consumer site(e.g RestTemplate), still need to use query parameters, can not use POJO. 
+5. In consumer site(e.g RestTemplate), still need to use query parameters, can not use POJO.
 
 ### Examples
 
@@ -158,12 +160,12 @@ paths:
   ```java
     String result = restTemplate.getForObject(
       "cse://provider-service/hello/sayHello?name=Bob&age=22",
-      String.class); 
+      String.class);
   ```
 
 ## ServiceComb suppoted Spring MVC annotations and differences
 
-ServiceComb supports Spring MVC annotatioins\(org.springframework.web.bind.annotation\) to define REST interfaces, but they are different. ServiceComb do not support @Controller frameworks and only support @RestController frameworks. 
+ServiceComb supports Spring MVC annotatioins\(org.springframework.web.bind.annotation\) to define REST interfaces, but they are different. ServiceComb do not support `@Controller` frameworks and only support `@RestController` frameworks.
 
 * Differences in supported annotations
 
@@ -196,14 +198,16 @@ ServiceComb supports Spring MVC annotatioins\(org.springframework.web.bind.annot
 
 * Define a REST service
 
-Spring MVC using @RestController to define a REST service，ServiceComb using @RestSchema to define a REST service，and path value in @RequestMapping is required.
+Spring MVC using `@RestController` to define a REST service，ServiceComb using `@RestSchema` to define a REST service，and path value in `@RequestMapping` is required.
 
-```
+```java
 @RestSchema(schemaId = "hello")
 @RequestMapping(path = "/")
 ```
 
-@RestController is also supported and equals to @RestSchma(schemaId="class name"). However we suggest using @RestSchemaand define a schemaId，it more convenient when used in configurations.  
+`@RestController` is also supported and equals to `@RestSchma(schemaId="class name")`. However we suggest using `@RestSchema` to define a schemaId，it's more convenient when used in configurations.  
+
+**Cautions**: If the classes with `@RestController` are not expected to be processed by ServiceComb-Java-Chassis and work as REST services, the config item `servicecomb.provider.rest.scanRestController=false` can be specified to disable the feature mentioned above.
 
 * Supported data types
 
@@ -220,7 +224,7 @@ public void postData(@RequestBody Map rawData)
 public void postData(HttpServletRequest rquest)
 ```
 
-ServiceComb need to generate Open API schemas based on definition, and support cross language features, so some of there usage is not supported. 
+ServiceComb need to generate Open API schemas based on definition, and support cross language features, so some of there usage is not supported.
 
 HttpServletRequest，Object is supported in latest version, but they are different. We suggest not using there features if possible.
 

--- a/java-chassis-reference/zh_CN/build-provider/springmvc.md
+++ b/java-chassis-reference/zh_CN/build-provider/springmvc.md
@@ -2,11 +2,11 @@
 
 ## 概念阐述
 
-ServiceComb支持SpringMVC注解，允许使用SpringMVC风格开发微服务。建议参照着项目 [SpringMVC](https://github.com/apache/servicecomb-java-chassis/tree/master/samples/springmvc-sample)进行详细阅读
+ServiceComb支持SpringMVC注解，允许使用SpringMVC风格开发微服务。建议参照着项目 [SpringMVC](https://github.com/apache/servicecomb-java-chassis/tree/master/samples/springmvc-sample) 进行详细阅读
 
 ## 开发示例
 
-### 步骤 1定义服务接口（可选，方便使用RPC方式调用）
+### 步骤1 定义服务接口（可选，方便使用RPC方式调用）
 
 定义接口不是必须的，但是 一个好习惯，可以简化客户端使用RPC方式编写代码。
 
@@ -19,7 +19,7 @@ public interface Hello {
 
 
 
-### 步骤 2实现服务
+### 步骤2 实现服务
 
 使用Spring MVC注解开发业务代码，Hello的服务实现如下。在服务的实现类上打上注解@RestSchema，指定schemaId，schemaId必须保证微服务范围内唯一。
 
@@ -41,7 +41,7 @@ public class SpringmvcHelloImpl implements Hello {
 }
 ```
 
-### 步骤 3发布服务 （可选，默认会扫描main函数所在的package）
+### 步骤3 发布服务 （可选，默认会扫描main函数所在的package）
 
 在`resources/META-INF/spring`目录下创建`springmvcprovider.bean.xml`文件，命名规则为`\*.bean.xml`，配置spring进行服务扫描的base-package，文件内容如下：
 
@@ -58,7 +58,7 @@ public class SpringmvcHelloImpl implements Hello {
 </beans>
 ```
 
-### 步骤 4启动provider 服务
+### 步骤4 启动provider 服务
 
 下面的代码使用Log4j作为日志记录器。开发者可以方便使用其他日志框架。
 
@@ -169,7 +169,7 @@ paths:
 
 ## ServiceComb支持的Spring MVC标签说明
 
-ServiceComb支持使用Spring MVC提供的标签\(org.springframework.web.bind.annotation\)来声明REST接口，但是两者是独立的实现，而且有不一样的设计目标。CSE的目标是提供跨语言、支持多通信协议的框架，因此去掉了Spring MVC中一些对跨语言支持不是很好的特性，也不支持特定运行框架强相关的特性，比如直接访问Servlet协议定义的HttpServletRequest。ServiceComb没有实现@Controller相关功能, 只实现了@RestController，即通过MVC模式进行页面渲染等功能都是不支持的。
+ServiceComb支持使用Spring MVC提供的标签\(org.springframework.web.bind.annotation\)来声明REST接口，但是两者是独立的实现，而且有不一样的设计目标。CSE的目标是提供跨语言、支持多通信协议的框架，因此去掉了Spring MVC中一些对跨语言支持不是很好的特性，也不支持特定运行框架强相关的特性，比如直接访问Servlet协议定义的`HttpServletRequest`。ServiceComb没有实现`@Controller`相关功能, 只实现了`@RestController`，即通过MVC模式进行页面渲染等功能都是不支持的。
 
 下面是一些具体差异。
 
@@ -206,7 +206,7 @@ ServiceComb支持使用Spring MVC提供的标签\(org.springframework.web.bind.a
 
 * 服务声明方式
 
-Spring MVC使用@RestController声明服务，而ServiceComb使用@RestSchema声明服务，并且需要显示的使用@RequestMapping声明服务路径，以区分该服务是采用Spring MVC的标签还是使用JAX RS的标签。
+Spring MVC使用`@RestController`声明服务，而ServiceComb使用`@RestSchema`声明服务，并且需要显式地使用`@RequestMapping`声明服务路径，以区分该服务是采用Spring MVC的标签还是使用JAX RS的标签。
 
 ```
 @RestSchema(schemaId = "hello")
@@ -215,7 +215,10 @@ Spring MVC使用@RestController声明服务，而ServiceComb使用@RestSchema声
 
 Schema是CSE的服务契约，是服务运行时的基础，服务治理、编解码等都基于契约进行。在跨语言的场景，契约也定义了不同语言能够同时理解的部分。
 
-最新版本也支持@RestController声明，等价于@RestSchma(schemaId="服务的class名称")，建议用户使用@RestSchema显示声明schemaId，在管理接口基本的配置项的时候，更加直观。
+最新版本也支持`@RestController`声明，等价于`@RestSchma(schemaId="服务的class名称")`，建议用户使用`@RestSchema`显式声明schemaId，在管理接口基本的配置项的时候，更加直观。
+
+**注意**：如果不希望Java-Chassis扫描`@RestController`注解作为REST接口类处理，需要增加配置
+`servicecomb.provider.rest.scanRestController=false`以关闭此功能。
 
 * 数据类型支持
 
@@ -240,4 +243,3 @@ ServiceComb在数据类型的支持方面的更多说明，请参考： [接口�
 
 * 其他
 更多开发过程中碰到的问题，可以参考[案例](https://bbs.huaweicloud.com/blogs/8b8d8584e70d11e8bd5a7ca23e93a891)。开发过程中存在疑问，也可以在这里进行提问。
-


### PR DESCRIPTION
We've declared that `@RestController` will be scanned as REST interface class. But users are not told how to disable this feature.
Description on the related configuration should be added.