### PR TITLE
修复【微服务信息配置项说明】文档中的错别字

### DIFF
--- a/java-chassis-reference/zh_CN/docs/build-provider/definition/service-definition.md
+++ b/java-chassis-reference/zh_CN/docs/build-provider/definition/service-definition.md
@@ -30,7 +30,7 @@ servicecomb 微服务定义包括两个基础模型 `Microservice` 和 `Microser
 | servicecomb.service.version | 2.1.2 | 1.0.0.0 | 是 | 微服务版本号 |
 | servicecomb.service.role | 2.1.2 | FRONT | 否 | 服务类型 |
 | servicecomb.service.description | 2.1.2 | - | 否 | 微服务描述 |
-| ervicecomb.service.environment | 2.1.2 | - | 否 | 运行环境，比如 development, production 等 |
+| servicecomb.service.environment | 2.1.2 | - | 否 | 运行环境，比如 development, production 等 |
 | servicecomb.service.propertyExtendedClass | 2.1.2 | - | 否 | 微服务元数据配置扩展信息， 接口返回的配置会覆盖配置文件中key相同的配置。|
 | servicecomb.service.properties | 2.1.2 | - | 否 | 服务实例元数据配置（通过microservice.yaml文件进行配置）|
 | servicecomb.service.paths | 2.1.2 | - | 否 | URL 前缀列表 |


### PR DESCRIPTION
- 修复【微服务信息配置项说明】文档中的错别字